### PR TITLE
Fixed highlighting non-visible chracters

### DIFF
--- a/grammars/batchfile.cson
+++ b/grammars/batchfile.cson
@@ -111,7 +111,7 @@
   'label':
     'patterns': [
       {
-        'match': ':[\\w][\\w -]+\\s'
+        'match': ':[\\w][\\w\\t -]+'
         'name': 'keyword.other.special-method.batchfile'
       }
     ]


### PR DESCRIPTION
Line 114 ended in \s which matched any whitespace character, including newlines and carriage returns.

I removed it and added \t to the group assuming that you want tabs highlighted. Otherwise, remove \\t  completely.