### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/grammars/batchfile.cson
+++ b/grammars/batchfile.cson
@@ -363,7 +363,7 @@
   'numbers':
     'patterns': [
       {
-        'match': '\\b(0[xX]\\h*|[+-]?\\d+)\\b'
+        'match': '\\b(0[xX][0-9A-Fa-f]*|[+-]?\\d+)\\b'
         'name': 'constant.numeric.batchfile'
       }
     ]


### PR DESCRIPTION
Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Atom uses an Oniguruma engine, but github.com relies on a PCRE
engine.