### PR TITLE
grammar: Ensure all capture groups have a `name` key

### DIFF
--- a/grammars/batchfile.cson
+++ b/grammars/batchfile.cson
@@ -395,10 +395,10 @@
       {
         'begin': '\\('
         'beginCaptures':
-          '0': 'punctuation.section.group.begin.batchfile'
+          '0': 'name': 'punctuation.section.group.begin.batchfile'
         'end': '\\)'
         'endCaptures':
-          '0': 'punctuation.section.group.end.batchfile'
+          '0': 'name': 'punctuation.section.group.end.batchfile'
         'name': 'meta.group.batchfile'
         'patterns': [
           {


### PR DESCRIPTION
Hey there! As you may know, we use this package to provide syntax highlighting for Batch files in GitHub.

I'm currently working on improving the way we load and perform syntax highlighting on the website, and I've noticed that there's an issue in the existing grammar which is choking our new parser.

Specifically: one of the beginCaptures groups is missing a name key, which results in small rendering issues as the capture group doesn't follow the usual semantics.

The proposed change fixes the issue in a backwards-compatible way. I'd appreciate if you could merge it. Thank you!