### PR TITLE
Param % scope and substitution fix for #29

### DIFF
--- a/grammars/batchfile.cson
+++ b/grammars/batchfile.cson
@@ -467,12 +467,11 @@
   'variables':
     'patterns': [
       {
-        'match': '(%)((~([fdpnxsatz]|\\$PATH:)*)?\\d|\\*)'
+        'match': '(%)(?:(?i:~[fdpnxsatz]*(?:\\$PATH:)?)?\\d|\\*)'
         'captures':
           '1':
             'name': 'punctuation.definition.variable.batchfile'
-          '2':
-            'name': 'variable.parameter.batchfile'
+        'name': 'variable.parameter.batchfile'
       }
       {
         'include': '#variable'

--- a/grammars/batchfile.cson
+++ b/grammars/batchfile.cson
@@ -4,11 +4,11 @@
   'bat'
   'cmd'
 ]
-"injections": 
-  "L:meta.block.repeat.batchfile": 
-    "patterns": [
+'injections':
+  'L:meta.block.repeat.batchfile':
+    'patterns': [
       {
-        "include": "#repeatParameter"
+        'include': '#repeatParameter'
       }
     ]
 'patterns': [
@@ -369,30 +369,30 @@
         'name': 'keyword.control.conditional.batchfile'
       }
       {
-        "begin": "(?<=^|[\\s(&^])(?i)for(?=\\s)"
-        "beginCaptures":
-          "0":
-              "name": "keyword.control.repeat.batchfile"
-        "name": "meta.block.repeat.batchfile"
-        "end": "\\n"
-        "patterns":[
+        'begin': '(?<=^|[\\s(&^])(?i)for(?=\\s)'
+        'beginCaptures':
+          '0':
+              'name': 'keyword.control.repeat.batchfile'
+        'name': 'meta.block.repeat.batchfile'
+        'end': '\\n'
+        'patterns':[
           {
-            "begin": "(?<=\\s|^)(?i)in(?=\\s)"
-            "beginCaptures":
-              "0":
-                "name": "keyword.control.repeat.in.batchfile"
-            "end": "(?<=[\\s)^])(?i)do(?=\\s)|\\n",
-            "endCaptures":
-              "0":
-                "name": "keyword.control.repeat.do.batchfile"
-            "patterns":[
+            'begin': '(?<=\\s|^)(?i)in(?=\\s)'
+            'beginCaptures':
+              '0':
+                'name': 'keyword.control.repeat.in.batchfile'
+            'end': '(?<=[\\s)^])(?i)do(?=\\s)|\\n',
+            'endCaptures':
+              '0':
+                'name': 'keyword.control.repeat.do.batchfile'
+            'patterns':[
               {
-                "include": "$self"
+                'include': '$self'
               }
             ]
           }
           {
-            "include": "$self"
+            'include': '$self'
           }
         ]
       }
@@ -470,14 +470,14 @@
         ]
       }
     ]
-  "repeatParameter":
-    "patterns": [
+  'repeatParameter':
+    'patterns': [
       {
-        "match": "(%%)(?:(?i:~[fdpnxsatz]*(?:\\$PATH:)?)?[a-zA-Z])"
-        "captures":
-          "1":
-            "name": "punctuation.definition.variable.batchfile"
-        "name": "variable.parameter.repeat.batchfile"
+        'match': '(%%)(?:(?i:~[fdpnxsatz]*(?:\\$PATH:)?)?[a-zA-Z])'
+        'captures':
+          '1':
+            'name': 'punctuation.definition.variable.batchfile'
+        'name': 'variable.parameter.repeat.batchfile'
       }
     ]
   'strings':

--- a/grammars/batchfile.cson
+++ b/grammars/batchfile.cson
@@ -377,7 +377,7 @@
         'end': '\\n'
         'patterns':[
           {
-            'begin': '(?<=\\s|^)(?i)in(?=\\s)'
+            'begin': '(?<=[\\s^])(?i)in(?=\\s)'
             'beginCaptures':
               '0':
                 'name': 'keyword.control.repeat.in.batchfile'

--- a/grammars/batchfile.cson
+++ b/grammars/batchfile.cson
@@ -5,12 +5,12 @@
   'cmd'
 ]
 "injections": 
-	"L:meta.block.repeat.batchfile": 
-		"patterns": [
-			{
-				"include": "#repeatParameter"
-			}
-		]
+  "L:meta.block.repeat.batchfile": 
+    "patterns": [
+      {
+        "include": "#repeatParameter"
+      }
+    ]
 'patterns': [
   {
     'include': '#commands'
@@ -368,37 +368,34 @@
         'match': '(?<=^|\\s)(?i)(?:if|else)(?=$|\\s)'
         'name': 'keyword.control.conditional.batchfile'
       }
-			{
-				"begin": "(?<=^|[\\s(&^])(?i)for(?=\\s)"
-				"beginCaptures":
-					"0":
-							"name": "keyword.control.repeat.batchfile"
-				"name": "meta.block.repeat.batchfile"
-				"end": "\\n"
-				"patterns":[
-					{
-						"begin": "(?<=\\s|^)(?i)in(?=\\s)"
-						"beginCaptures":
-							"0":
-								"name": "keyword.control.repeat.in.batchfile"
-						"end": "(?<=[\\s)^])(?i)do(?=\\s)|\\n",
-						"endCaptures":
-							"0":
-								"name": "keyword.control.repeat.do.batchfile"
+      {
+        "begin": "(?<=^|[\\s(&^])(?i)for(?=\\s)"
+        "beginCaptures":
+          "0":
+              "name": "keyword.control.repeat.batchfile"
+        "name": "meta.block.repeat.batchfile"
+        "end": "\\n"
+        "patterns":[
+          {
+            "begin": "(?<=\\s|^)(?i)in(?=\\s)"
+            "beginCaptures":
+              "0":
+                "name": "keyword.control.repeat.in.batchfile"
+            "end": "(?<=[\\s)^])(?i)do(?=\\s)|\\n",
+            "endCaptures":
+              "0":
+                "name": "keyword.control.repeat.do.batchfile"
             "patterns":[
               {
                 "include": "$self"
               }
             ]
-					}
-					{
-						"include": "#repeatParameter"
-					}
-					{
-						"include": "$self"
-					}
-				]
-			}
+          }
+          {
+            "include": "$self"
+          }
+        ]
+      }
     ]
   'escaped_characters':
     'patterns': [
@@ -474,15 +471,15 @@
       }
     ]
   "repeatParameter":
-		"patterns": [
-			{
-				"match": "(%%)(?:(?i:~[fdpnxsatz]*(?:\\$PATH:)?)?[a-zA-Z])"
-				"captures":
-					"1":
-						"name": "punctuation.definition.variable.batchfile"
-				"name": "variable.parameter.repeat.batchfile"
-			}
-		]
+    "patterns": [
+      {
+        "match": "(%%)(?:(?i:~[fdpnxsatz]*(?:\\$PATH:)?)?[a-zA-Z])"
+        "captures":
+          "1":
+            "name": "punctuation.definition.variable.batchfile"
+        "name": "variable.parameter.repeat.batchfile"
+      }
+    ]
   'strings':
     'patterns': [
       {

--- a/grammars/batchfile.cson
+++ b/grammars/batchfile.cson
@@ -4,6 +4,13 @@
   'bat'
   'cmd'
 ]
+"injections": 
+	"L:meta.block.repeat.batchfile": 
+		"patterns": [
+			{
+				"include": "#repeatParameter"
+			}
+		]
 'patterns': [
   {
     'include': '#commands'
@@ -361,10 +368,37 @@
         'match': '(?<=^|\\s)(?i)(?:if|else)(?=$|\\s)'
         'name': 'keyword.control.conditional.batchfile'
       }
-      {
-        'match': '(?<=^|\\s)(?i)for(?=\\s)'
-        'name': 'keyword.control.repeat.batchfile'
-      }
+			{
+				"begin": "(?<=^|[\\s(&^])(?i)for(?=\\s)"
+				"beginCaptures":
+					"0":
+							"name": "keyword.control.repeat.batchfile"
+				"name": "meta.block.repeat.batchfile"
+				"end": "\\n"
+				"patterns":[
+					{
+						"begin": "(?<=\\s|^)(?i)in(?=\\s)"
+						"beginCaptures":
+							"0":
+								"name": "keyword.control.repeat.in.batchfile"
+						"end": "(?<=[\\s)^])(?i)do(?=\\s)|\\n",
+						"endCaptures":
+							"0":
+								"name": "keyword.control.repeat.do.batchfile"
+            "patterns":[
+              {
+                "include": "$self"
+              }
+            ]
+					}
+					{
+						"include": "#repeatParameter"
+					}
+					{
+						"include": "$self"
+					}
+				]
+			}
     ]
   'escaped_characters':
     'patterns': [
@@ -439,6 +473,16 @@
         ]
       }
     ]
+  "repeatParameter":
+		"patterns": [
+			{
+				"match": "(%%)(?:(?i:~[fdpnxsatz]*(?:\\$PATH:)?)?[a-zA-Z])"
+				"captures":
+					"1":
+						"name": "punctuation.definition.variable.batchfile"
+				"name": "variable.parameter.repeat.batchfile"
+			}
+		]
   'strings':
     'patterns': [
       {


### PR DESCRIPTION
This changes the scope of the % at the beginning of a batch parameter (ie `%1`) so that it is included in the variable scope along with the rest of the item, so that the whole thing (`%1` or `%~dp$PATH:1`) themes as a variable as do regular variable expansions (`%variable%`).

This also corrects the allowed syntax of the substitution parts, as `$PATH:` must come last, and only once.  Also, allows any case for the entire substitution.  Optimized this match to not capture anything not separately scoped.

This is for issue #29.

Previously:
![image](https://user-images.githubusercontent.com/26179051/45135366-90dc4200-b164-11e8-8026-c61fcb416a2f.png)

Now:
![image](https://user-images.githubusercontent.com/26179051/45135421-f5979c80-b164-11e8-9f9b-6b355f2c2449.png)

Examples produced on VS Code 1.27.0 - Monokai Dimmed