### PR TITLE
Fixed command_set_operators and label

### DIFF
--- a/grammars/batchfile.cson
+++ b/grammars/batchfile.cson
@@ -369,7 +369,7 @@
   'escaped_characters':
     'patterns': [
       {
-        'match': '%%|\\^\\^!|\\^(?=.)|\\^\\n'
+        'match': '%%|\\^\\^!|\\^.|\\^\\n'
         'name': 'constant.character.escape.batchfile'
       }
     ]

--- a/grammars/batchfile.cson
+++ b/grammars/batchfile.cson
@@ -376,7 +376,7 @@
   'labels':
     'patterns': [
       {
-        'match': '(?i)(?:^\\s*|(?<=goto)\\s*)(:)([^+=,;:\\s].*)$'
+        'match': '(?i)(?:^\\s*|(?<=call|goto)\\s*)(:)([^+=,;:\\s]\\S*)'
         'captures':
           '1':
             'name': 'punctuation.separator.batchfile'

--- a/grammars/batchfile.cson
+++ b/grammars/batchfile.cson
@@ -252,7 +252,7 @@
         'name': 'keyword.operator.logical.batchfile'
       }
       {
-        'match': '([^ ][^=]*)(=)'
+        'match': '([^ =]*)(=)'
         'captures':
           '1':
             'name': 'variable.other.readwrite.batchfile'


### PR DESCRIPTION
No longer highlights the variable that begins with `=` in `set /a` and fixes Issue #34